### PR TITLE
Added support for Windows version of CAENHVWrapper Library

### DIFF
--- a/src/pycaenhv/_lib.py
+++ b/src/pycaenhv/_lib.py
@@ -2,9 +2,9 @@ from ctypes import CDLL
 from .utils import find_dll
 
 def load_lib():
-    """ Find and load libcaenhvwrapper.so
+    """ Find and load CAENHVWrapper Library
     """
     lib_path = find_dll()
     if lib_path is None:
-        raise ValueError('Cannot find libcaenhvwrapper.so in known library paths or LD_LIBRARY_PATH')
+        raise ValueError('Cannot find CAENHVWrapper in known library paths or LD_LIBRARY_PATH')
     return CDLL(str(lib_path))

--- a/src/pycaenhv/utils/dll_finder.py
+++ b/src/pycaenhv/utils/dll_finder.py
@@ -1,20 +1,34 @@
 from glob import glob
 from pathlib import Path
 import os
+import platform
 from typing import List, Union, Optional
 
-SEARCH_DIRECTORIES = [
-    '/lib', '/lib64', '/usr/lib', '/usr/lib64', '/usr/local/lib',
-    '/usr/local/lib64', '~/local/lib', '~/local/lib64'
-]
+if platform.system() == 'Windows':
 
-search_pattern = 'libcaenhvwrapper.so*'
+    SEARCH_DIRECTORIES = [
+        'C:\Windows\System32'
+    ]
+
+    search_pattern = 'CAENHVWrapper.dll'
+
+elif platform.system() == 'Linux':
+    SEARCH_DIRECTORIES = [
+        '/lib', '/lib64', '/usr/lib', '/usr/lib64', '/usr/local/lib',
+        '/usr/local/lib64', '~/local/lib', '~/local/lib64'
+    ]
+
+    search_pattern = 'libcaenhvwrapper.so*'
+
+else:
+    print('Operating system not supported')
+
 
 
 def find_dll(
         extra_dirs: Optional[List[Union[str,
                                         Path]]] = None) -> Union[Path, None]:
-    """ Search for libcaenhvwrapper.so* in known places
+    """ Search for CAENHVWrapper in known places
     """
     _search_dirs = SEARCH_DIRECTORIES + []
     if os.environ.get('LD_LIBRARY_PATH', None):


### PR DESCRIPTION
### Overview
There are two versions of the CAENHVWrapper library - one for Windows and one for Linux. Previously, this package worked with the Linux version but now it works with the Windows version as well.

I've tested it with the windows version of the library and everything seems to be functioning well.